### PR TITLE
Update test and fix predict method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-src/sklearn_nv/__pycache__/
+__pycache__

--- a/src/sklearn_nv/kmeans.py
+++ b/src/sklearn_nv/kmeans.py
@@ -164,12 +164,18 @@ class KMeansEngine:  # (_kmeans.KMeansCythonEngine):
         # XXX cp.unique() doesn't support the axis arg yet :(
         return cluster_labels.shape[0]
 
+    def prepare_prediction(self, X, sample_weight=None):
+        X = cp.asarray(X)
+        if sample_weight is not None:
+            sample_weight = cp.asarray(sample_weight)
+        return X, sample_weight
+
     def get_labels(self, X, sample_weight):
         X = cp.asarray(X)
         labels = pairwise_distances_argmin(
-            X, self.estimator.cluster_centers_, handle=self.raft_handle
+            X,
+            self.estimator.cluster_centers_,
         )
-        self.raft_handle.sync()
         return labels.ravel()
 
     def is_same_clustering(self, labels, best_labels, n_clusters):

--- a/tests/test_kmeans.py
+++ b/tests/test_kmeans.py
@@ -7,13 +7,35 @@ from sklearn.cluster import KMeans
 from sklearn.datasets import make_blobs
 from sklearn.model_selection import train_test_split
 
+from sklearn_nv.kmeans import _is_same_clustering
+
+
+def same_rows(a, b):
+    """Determine if the rows are the same, up to a permutation.
+
+    Check that all rows that appear in `b` are also in `a`, allowing
+    for the order of the rows to be different.
+    """
+    if a.shape != b.shape:
+        return False
+
+    for row_a in a:
+        for row_b in b:
+            if np.allclose(row_a, row_b):
+                break
+        else:
+            return False
+
+    return True
+
 
 def test_sklearn_equivalence():
     X, y_true = make_blobs(
         n_samples=30, centers=4, n_features=3, cluster_std=0.60, random_state=10
     )
 
-    kmeans_args = dict(n_clusters=4, random_state=42, n_init=1)
+    n_clusters = 4
+    kmeans_args = dict(n_clusters=n_clusters, random_state=42, n_init=1)
 
     # Default implementation
     km = KMeans(**kmeans_args)
@@ -22,13 +44,13 @@ def test_sklearn_equivalence():
     y_pred = km.predict(X)
 
     # Using the accelerated version
-    with sklearn.config_context(engine_provider="sklearn_gpu"):
+    with sklearn.config_context(engine_provider="sklearn_nv"):
         km2 = KMeans(**kmeans_args)
         km2.fit(X)
 
         y_pred2 = km2.predict(X)
 
-    assert np.allclose(km.cluster_centers_, km2.cluster_centers_)
+    assert same_rows(km.cluster_centers_, km2.cluster_centers_)
     assert np.allclose(km.inertia_, km2.inertia_)
-    assert np.allclose(y_pred, y_pred2)
+    assert _is_same_clustering(y_pred, y_pred2, n_clusters)
     assert km.n_iter_ == km2.n_iter_


### PR DESCRIPTION
Closes #3 

This adds a missing methods to make `predict`ions work again.

Also updates the test to be able to deal with the same clusters being found but in a different order.